### PR TITLE
保存FPUレジスタのコメントがコードと一致していないのを修正

### DIFF
--- a/kernel/sysdepend/cpu/core/armv7m/dispatch.S
+++ b/kernel/sysdepend/cpu/core/armv7m/dispatch.S
@@ -95,7 +95,7 @@ l_dispatch_000:
 	ands	r3,lr, #EXPRN_NO_FPU
 	bne	l_dispatch_010			// ctxtsk does not execute FPU instructions.
 
-	vpush	{s16-s31}			// Push FPU register (S15-S31)
+	vpush	{s16-s31}			// Push FPU register (S16-S31)
 	push	{r3}				//FPU usage flag
 
 l_dispatch_010:			// End of FPU register save process
@@ -148,7 +148,7 @@ l_dispatch_120:			// Switch to 'schedtsk'
 	bne	l_dispatch_200			// schedtsk does not execute FPU instructions.
 
 	pop	{r3}
-	vpop	{s16-s31}			// Pop FPU register (S15-S31)
+	vpop	{s16-s31}			// Pop FPU register (S16-S31)
 
 l_dispatch_200:			//  End of FPU register restore process
 #endif	/* USE_FPU */


### PR DESCRIPTION
保存FPUレジスタのコメントがコードと一致していないのの修正です