### PR TITLE
mtkernel_3: apply code spell check across entire code base

### DIFF
--- a/device/adc/sysdepend/rx231/adc_rx231.c
+++ b/device/adc/sysdepend/rx231/adc_rx231.c
@@ -70,7 +70,7 @@ LOCAL UW adc_convert( INT start, INT size, UW *buf )
 		}
 	}
 
-	out_h(ADCSR, ADCSR_ADST | ADCSR_ADIE);	// Start Covert
+	out_h(ADCSR, ADCSR_ADST | ADCSR_ADIE);	// Start Convert
 
 	err = tk_slp_tsk(DEVCNF_ADC_TMOSCAN);
 	if(err != E_OK) return (UW)err;

--- a/device/adc/sysdepend/rx231/adc_sysdep.h
+++ b/device/adc/sysdepend/rx231/adc_sysdep.h
@@ -21,10 +21,10 @@
 #ifndef	__DEV_ADC_RX231_H__
 #define	__DEV_ADC_RX231_H__
 
-#define	DEV_ADC_UNITNM	(1)	/* Number of devive units */
+#define	DEV_ADC_UNITNM	(1)	/* Number of device units */
 #define	DEV_ADC_UNIT0	(0)
 
-#define ADC_CH_NUM	(24)		/* Number of A/DC chanels */
+#define ADC_CH_NUM	(24)		/* Number of A/DC channels */
 
 /*
  * ADC registers
@@ -37,10 +37,10 @@
 #define	ADCER_INI	(1<<5)			/* register initial value */
 
 
-#define	ADANSA0		(0x00089004)		/* A/D chanel select reg. A0*/
-#define	ADANSA1		(0x00089006)		/* A/D chanel select reg. A1*/
-#define	ADANSB0		(0x00089014)		/* A/D chanel select reg. B0*/
-#define	ADANSB1		(0x00089016)		/* A/D chanel select reg. B1*/
+#define	ADANSA0		(0x00089004)		/* A/D channel select reg. A0*/
+#define	ADANSA1		(0x00089006)		/* A/D channel select reg. A1*/
+#define	ADANSB0		(0x00089014)		/* A/D channel select reg. B0*/
+#define	ADANSB1		(0x00089016)		/* A/D channel select reg. B1*/
 
 #define	ADDR(c)		(0x00089020 + 2*c)	/* A/D Data reg. */
 

--- a/device/adc/sysdepend/rx65n/adc_rx65n.c
+++ b/device/adc/sysdepend/rx65n/adc_rx65n.c
@@ -30,11 +30,11 @@
 const LOCAL UW ba[DEV_ADC_UNITNM] = { ADC0_BASE, ADC1_BASE };
 
 #define	ADC_ADCSR(x)	(ba[x] + ADCx_ADCSR)		// A/DC control reg
-#define	ADC_ADANSA0(x)	(ba[x] + ADCx_ADANSA0)		// A/DC chanel select reg. A0
-#define	ADC_ADANSA1(x)	(ba[x] + ADCx_ADANSA1)		// A/DC chanel select reg. A1
+#define	ADC_ADANSA0(x)	(ba[x] + ADCx_ADANSA0)		// A/DC channel select reg. A0
+#define	ADC_ADANSA1(x)	(ba[x] + ADCx_ADANSA1)		// A/DC channel select reg. A1
 #define	ADC_ADCER(x)	(ba[x] + ADCx_ADCER)		// A/DC Control extension reg
-#define	ADC_ADANSB0(x)	(ba[x] + ADCx_ADANSB0)		// A/DC chanel select reg. B0
-#define	ADC_ADANSB1(x)	(ba[x] + ADCx_ADANSB1)		// A/DC chanel select reg. B1
+#define	ADC_ADANSB0(x)	(ba[x] + ADCx_ADANSB0)		// A/DC channel select reg. B0
+#define	ADC_ADANSB1(x)	(ba[x] + ADCx_ADANSB1)		// A/DC channel select reg. B1
 
 #define	ADC_ADDR(x,c)	(ba[x] + ADCx_ADDR(c))		//A/DC Data reg
 #define	ADC_ADSSTR(x,c)	(ba[x] + ADCx_ADSSTR(c))	//A/DC Sampling state reg
@@ -98,7 +98,7 @@ LOCAL UW adc_convert( UW unit, INT start, INT size, UW *buf )
 		}
 	}
 
-	out_h(ADC_ADCSR(unit), ADCSR_ADST | ADCSR_ADIE);	// Start Covert
+	out_h(ADC_ADCSR(unit), ADCSR_ADST | ADCSR_ADIE);	// Start Convert
 
 	err = tk_slp_tsk(DEVCNF_ADC_TMOSCAN);
 	if(err != E_OK) return (UW)err;

--- a/device/adc/sysdepend/rx65n/adc_sysdep.h
+++ b/device/adc/sysdepend/rx65n/adc_sysdep.h
@@ -21,11 +21,11 @@
 #ifndef	__DEV_ADC_RX65N_H__
 #define	__DEV_ADC_RX65N_H__
 
-#define	DEV_ADC_UNITNM	(2)	/* Number of devive units */
+#define	DEV_ADC_UNITNM	(2)	/* Number of device units */
 #define	DEV_ADC_UNIT0	(0)
 #define	DEV_ADC_UNIT1	(1)
 
-#define ADC_CH_NUM0	(8)		/* Number of A/DC chanels */
+#define ADC_CH_NUM0	(8)		/* Number of A/DC channels */
 #define ADC_CH_NUM1	(21)
 
 /*
@@ -41,11 +41,11 @@
 #define	ADCSR_ADST	(1<<15)
 #define	ADCSR_ADIE	(1<<12)
 
-#define	ADCx_ADANSA0	(0x04)		/* A/DC chanel select reg. A0*/
-#define	ADCx_ADANSA1	(0x06)		/* A/DC chanel select reg. A1*/
+#define	ADCx_ADANSA0	(0x04)		/* A/DC channel select reg. A0*/
+#define	ADCx_ADANSA1	(0x06)		/* A/DC channel select reg. A1*/
 #define	ADCx_ADCER	(0x0E)		/* A/DC Control extension reg. */
-#define	ADCx_ADANSB0	(0x14)		/* A/DC chanel select reg. B0*/
-#define	ADCx_ADANSB1	(0x16)		/* A/DC chanel select reg. B1*/
+#define	ADCx_ADANSB0	(0x14)		/* A/DC channel select reg. B0*/
+#define	ADCx_ADANSB1	(0x16)		/* A/DC channel select reg. B1*/
 
 #define	ADCx_ADDR(c)	(0x20+(2*c))	/* A/DC Data reg. */
 

--- a/device/adc/sysdepend/rza2m/adc_rza2m.c
+++ b/device/adc/sysdepend/rza2m/adc_rza2m.c
@@ -65,7 +65,7 @@ LOCAL UW adc_convert( INT start, INT size, UW *buf )
 	}
 	out_h(ADANSA0, chset);
 
-	out_h(ADCSR, ADCSR_ADST | ADCSR_ADIE);		// Start Covert
+	out_h(ADCSR, ADCSR_ADST | ADCSR_ADIE);		// Start Convert
 
 	err = tk_slp_tsk(DEVCNF_ADC_TMOSCAN);
 	if(err != E_OK) return (UW)err;

--- a/device/adc/sysdepend/rza2m/adc_sysdep.h
+++ b/device/adc/sysdepend/rza2m/adc_sysdep.h
@@ -21,10 +21,10 @@
 #ifndef	__DEV_ADC_RZA2M_H__
 #define	__DEV_ADC_RZA2M_H__
 
-#define	DEV_ADC_UNITNM	(1)		/* Number of devive units */
+#define	DEV_ADC_UNITNM	(1)		/* Number of device units */
 #define	DEV_ADC_UNIT0	(0)
 
-#define ADC_CH_NUM	(8)		/* Number of A/DC chanels */
+#define ADC_CH_NUM	(8)		/* Number of A/DC channels */
 
 /*
  * ADC registers

--- a/device/adc/sysdepend/stm32h7/adc_stm32h7.c
+++ b/device/adc/sysdepend/stm32h7/adc_stm32h7.c
@@ -126,7 +126,7 @@ LOCAL UW adc_convert( UINT unit, INT ch, INT size, UW *buf )
 	ll_devcb[unit].buf = buf;
 
 	tk_can_wup(TSK_SELF);
-	out_w(ADC_CR(unit), ADC_CR_ADSTART | ADC_CR_ADVREGEN);	// Start Covert
+	out_w(ADC_CR(unit), ADC_CR_ADSTART | ADC_CR_ADVREGEN);	// Start Convert
 	err = tk_slp_tsk(DEVCNF_ADC_TMOSCAN);
 	ll_devcb[unit].wait_tskid = 0;
 

--- a/device/adc/sysdepend/stm32h7/adc_sysdep.h
+++ b/device/adc/sysdepend/stm32h7/adc_sysdep.h
@@ -20,12 +20,12 @@
 #ifndef	__DEV_ADC_STM32H7_H__
 #define	__DEV_ADC_STM32H7_H__
 
-#define	DEV_ADC_UNITNM	(3)	/* Number of devive units */
+#define	DEV_ADC_UNITNM	(3)	/* Number of device units */
 #define	DEV_ADC_1	(0)	/* ADC1 */
 #define	DEV_ADC_2	(1)	/* ADC2 */
 #define	DEV_ADC_3	(2)	/* ADC3 */
 
-/* NUmber of A/DC chanels */
+/* NUmber of A/DC channels */
 #define	ADC_CH_NUM	(20)
 #define	ADC_MAX_SQ	(16)
 

--- a/device/adc/sysdepend/stm32l4/adc_stm32l4.c
+++ b/device/adc/sysdepend/stm32l4/adc_stm32l4.c
@@ -116,7 +116,7 @@ LOCAL UW adc_convert( UINT unit, INT ch, INT size, UW *buf )
 	ll_devcb[unit].asz = 0;
 
 	tk_can_wup(TSK_SELF);
-	out_w(ADC_CR(unit), ADC_CR_ADSTART | ADC_CR_ADVREGEN);	// Start Covert
+	out_w(ADC_CR(unit), ADC_CR_ADSTART | ADC_CR_ADVREGEN);	// Start Convert
 	err = tk_slp_tsk(DEVCNF_ADC_TMOSCAN);
 	ll_devcb[unit].wait_tskid = 0;
 

--- a/device/adc/sysdepend/stm32l4/adc_sysdep.h
+++ b/device/adc/sysdepend/stm32l4/adc_sysdep.h
@@ -20,12 +20,12 @@
 #ifndef	__DEV_ADC_STM32L4_H__
 #define	__DEV_ADC_STM32L4_H__
 
-#define	DEV_ADC_UNITNM	(3)	/* Number of devive units */
+#define	DEV_ADC_UNITNM	(3)	/* Number of device units */
 #define	DEV_ADC_1	(0)	/* ADC1 */
 #define	DEV_ADC_2	(1)	/* ADC2 */
 #define	DEV_ADC_3	(2)	/* ADC3 */
 
-/* NUmber of A/DC chanels */
+/* NUmber of A/DC channels */
 #define	ADC_CH_NUM	(19)
 #define	ADC_MAX_SQ	(16)
 

--- a/device/adc/sysdepend/tx03_m367/adc_m367.c
+++ b/device/adc/sysdepend/tx03_m367/adc_m367.c
@@ -89,7 +89,7 @@ LOCAL UW adc_convert( UINT unit, INT ch, INT size, UW *buf )
 	}
 
 	tk_can_wup(TSK_SELF);
-	out_w( ba[unit] + ADxMOD0, ADxMOD0_ADS);	// MOD0.ADS = 1  Start Covert
+	out_w( ba[unit] + ADxMOD0, ADxMOD0_ADS);	// MOD0.ADS = 1  Start Convert
 
 	rtn = (UW)tk_slp_tsk(unit?DEVCNF_ADCB_INTPRI:DEVCNF_ADCA_TMOSCAN);
 	if(rtn == E_OK) {

--- a/device/adc/sysdepend/tx03_m367/adc_sysdep.h
+++ b/device/adc/sysdepend/tx03_m367/adc_sysdep.h
@@ -21,11 +21,11 @@
 #ifndef	__DEV_ADC_M367_H__
 #define	__DEV_ADC_M367_H__
 
-#define	DEV_ADC_UNITNM	(2)	/* Number of devive units */
+#define	DEV_ADC_UNITNM	(2)	/* Number of device units */
 #define	DEV_ADC_UNIT0	(0)
 #define	DEV_ADC_UNIT1	(1)
 
-#define ADC_CH_NUM	(4)		/* NUmber of A/DC chanels */
+#define ADC_CH_NUM	(4)		/* NUmber of A/DC channels */
 
 /*
  * ADC registers

--- a/device/common/drvif/msdrvif.c
+++ b/device/common/drvif/msdrvif.c
@@ -23,7 +23,7 @@
 
 /* ------------------------------------------------------------------------ */
 /*
- * FastLock fot driver I/F access
+ * FastLock for driver I/F access
  */
 
 #define	LockMSDI(msdi)		Lock(&msdi->lock)

--- a/device/i2c/sysdepend/rx231/i2c_sysdep.h
+++ b/device/i2c/sysdepend/rx231/i2c_sysdep.h
@@ -20,7 +20,7 @@
 #ifndef	__DEV_I2C_RX231_H__
 #define	__DEV_I2C_RX231_H__
 
-#define	DEV_I2C_UNITNM		(1)	/* Number of devive units */
+#define	DEV_I2C_UNITNM		(1)	/* Number of device units */
 
 /* I2C device driver operating state */
 #define	I2C_STS_START		0x0000

--- a/device/i2c/sysdepend/rx65n/i2c_sysdep.h
+++ b/device/i2c/sysdepend/rx65n/i2c_sysdep.h
@@ -20,7 +20,7 @@
 #ifndef	__DEV_I2C_RX65N_H__
 #define	__DEV_I2C_RX65N_H__
 
-#define	DEV_I2C_UNITNM	(3)	// Number of devive units
+#define	DEV_I2C_UNITNM	(3)	// Number of device units
 #define	DEV_I2C_UNIT0	(0)
 #define	DEV_I2C_UNIT1	(1)
 #define	DEV_I2C_UNIT2	(2)

--- a/device/i2c/sysdepend/rza2m/i2c_sysdep.h
+++ b/device/i2c/sysdepend/rza2m/i2c_sysdep.h
@@ -20,7 +20,7 @@
 #ifndef	__DEV_I2C_RZA2M_H__
 #define	__DEV_I2C_RZA2M_H__
 
-#define	DEV_I2C_UNITNM		(4)	/* Number of devive units */
+#define	DEV_I2C_UNITNM		(4)	/* Number of device units */
 #define	DEV_I2C_0		(0)	/* RIIC0 */
 #define	DEV_I2C_1		(1)	/* RIIC1 */
 #define	DEV_I2C_2		(2)	/* RIIC2 */
@@ -106,7 +106,7 @@
 #define	INTNO_RIIC_SPI0		267		// STOP condition detection interrupt
 #define	INTNO_RIIC_STI0		268		// START condition detection interrupt
 #define	INTNO_RIIC_NAKI0	269		// NACK reception interrupt
-#define	INTNO_RIIC_ALI0		270		// Abitration lost interrupt
+#define	INTNO_RIIC_ALI0		270		// Arbitration lost interrupt
 #define	INTNO_RIIC_TMOI0	271		// Time out interrupt
 
 #define	INTNO_RIIC_TEI1		272		// Transmit end interrupt
@@ -115,7 +115,7 @@
 #define	INTNO_RIIC_SPI1		275		// STOP condition detection interrupt
 #define	INTNO_RIIC_STI1		276		// START condition detection interrupt
 #define	INTNO_RIIC_NAKI1	277		// NACK reception interrupt
-#define	INTNO_RIIC_ALI1		278		// Abitration lost interrupt
+#define	INTNO_RIIC_ALI1		278		// Arbitration lost interrupt
 #define	INTNO_RIIC_TMOI1	279		// Time out interrupt
 
 #define	INTNO_RIIC_TEI2		280		// Transmit end interrupt
@@ -124,7 +124,7 @@
 #define	INTNO_RIIC_SPI2		283		// STOP condition detection interrupt
 #define	INTNO_RIIC_STI2		284		// START condition detection interrupt
 #define	INTNO_RIIC_NAKI2	285		// NACK reception interrupt
-#define	INTNO_RIIC_ALI2		286		// Abitration lost interrupt
+#define	INTNO_RIIC_ALI2		286		// Arbitration lost interrupt
 #define	INTNO_RIIC_TMOI2	287		// Time out interrupt
 
 #define	INTNO_RIIC_TEI3		288		// Transmit end interrupt
@@ -133,7 +133,7 @@
 #define	INTNO_RIIC_SPI3		291		// STOP condition detection interrupt
 #define	INTNO_RIIC_STI3		292		// START condition detection interrupt
 #define	INTNO_RIIC_NAKI3	293		// NACK reception interrupt
-#define	INTNO_RIIC_ALI3		294		// Abitration lost interrupt
+#define	INTNO_RIIC_ALI3		294		// Arbitration lost interrupt
 #define	INTNO_RIIC_TMOI3	295		// Time out interrupt
 
 #endif	/* __DEV_I2C_RZA2M_H__ */

--- a/device/i2c/sysdepend/stm32h7/i2c_sysdep.h
+++ b/device/i2c/sysdepend/stm32h7/i2c_sysdep.h
@@ -20,7 +20,7 @@
 #ifndef	__DEV_I2C_STM32H7_H__
 #define	__DEV_I2C_STM32H7_H__
 
-#define	DEV_I2C_UNITNM		(5)	/* Number of devive units */
+#define	DEV_I2C_UNITNM		(5)	/* Number of device units */
 #define	DEV_I2C_1		(0)	/* I2C1 */
 #define	DEV_I2C_2		(1)	/* I2C2 */
 #define	DEV_I2C_3		(2)	/* I2C3 */
@@ -53,8 +53,8 @@
 /* Register offset */
 #define	I2Cx_CR1		(0x00)		// Control register 1
 #define	I2Cx_CR2		(0x04)		// Control register 2
-#define	I2Cx_OAR1		(0x08)		// Own adress 1 register
-#define	I2Cx_OAR2		(0x0C)		// Own adress 2 register
+#define	I2Cx_OAR1		(0x08)		// Own address 1 register
+#define	I2Cx_OAR2		(0x0C)		// Own address 2 register
 #define	I2Cx_TIMINGR		(0x10)		// Timing register
 #define	I2Cx_TIMEOUTR		(0x14)		// Timeout register
 #define	I2Cx_ISR		(0x18)		// Interrupt & status register

--- a/device/i2c/sysdepend/stm32l4/i2c_sysdep.h
+++ b/device/i2c/sysdepend/stm32l4/i2c_sysdep.h
@@ -20,7 +20,7 @@
 #ifndef	__DEV_I2C_STM32L4_H__
 #define	__DEV_I2C_STM32L4_H__
 
-#define	DEV_I2C_UNITNM		(3)	/* Number of devive units */
+#define	DEV_I2C_UNITNM		(3)	/* Number of device units */
 #define	DEV_I2C_1		(0)	/* I2C1 */
 #define	DEV_I2C_2		(1)	/* I2C2 */
 #define	DEV_I2C_3		(2)	/* I2C3 */
@@ -50,8 +50,8 @@
 /* Register offset */
 #define	I2Cx_CR1		(0x00)		// Control register 1
 #define	I2Cx_CR2		(0x04)		// Control register 2
-#define	I2Cx_OAR1		(0x08)		// Own adress 1 register
-#define	I2Cx_OAR2		(0x0C)		// Own adress 2 register
+#define	I2Cx_OAR1		(0x08)		// Own address 1 register
+#define	I2Cx_OAR2		(0x0C)		// Own address 2 register
 #define	I2Cx_TIMINGR		(0x10)		// Timing register
 #define	I2Cx_TIMEOUTR		(0x14)		// Timeout register
 #define	I2Cx_ISR		(0x18)		// Interrupt & status register

--- a/device/i2c/sysdepend/tx03_m367/i2c_sysdep.h
+++ b/device/i2c/sysdepend/tx03_m367/i2c_sysdep.h
@@ -20,7 +20,7 @@
 #ifndef	__DEV_I2C_M367_H__
 #define	__DEV_I2C_M367_H__
 
-#define	DEV_I2C_UNITNM		(3)	/* Number of devive units */
+#define	DEV_I2C_UNITNM		(3)	/* Number of device units */
 
 /* I2C device driver operating state */
 #define	I2C_STS_START		0x0000

--- a/device/include/dev_ser.h
+++ b/device/include/dev_ser.h
@@ -37,7 +37,7 @@ typedef enum {
 } T_DN_SER_ATR;
 
 /* Communication Error */
-#define	DEV_SER_ERR_ROVR	(1<<7)	/* Recive buffe over flow */
+#define	DEV_SER_ERR_ROVR	(1<<7)	/* Receive buffer over flow */
 
 /*----------------------------------------------------------------------*/
 /* Hardware dependent definition

--- a/device/ser/ser.h
+++ b/device/ser/ser.h
@@ -62,7 +62,7 @@ typedef struct {
 	TMO	snd_tmo;	/* Send timeout */
 	TMO	rcv_tmo;	/* Receive timeout */
 
-	/* Intrrupt */
+	/* Interrupt */
 	UINT	intno_rcv;	/* Receive interrupt number */
 	UINT	intno_snd;	/* Send interrupt number */
 	UINT	int_pri;	/* Interrupt priority */

--- a/device/ser/sysdepend/rx231/ser_rx231.c
+++ b/device/ser/sysdepend/rx231/ser_rx231.c
@@ -59,7 +59,7 @@ const LOCAL INT pritbl[DEV_SER_UNITNM] = {
 */
 typedef struct {
 	UW	mode;		// Serial mode
-	UW	speed;		// Spped (bit rate)
+	UW	speed;		// Speed (bit rate)
 } T_DEV_SER_LLDEVCB;
 
 LOCAL T_DEV_SER_LLDEVCB		ll_devcb[DEV_SER_UNITNM];

--- a/device/ser/sysdepend/rx231/ser_sysdep.h
+++ b/device/ser/sysdepend/rx231/ser_sysdep.h
@@ -21,7 +21,7 @@
 #ifndef	__DEV_SER_RX231_H__
 #define	__DEV_SER_RX231_H__
 
-#define	DEV_SER_UNITNM		(7)	/* Number of devive channels */
+#define	DEV_SER_UNITNM		(7)	/* Number of device channels */
 
 /*
  * UART registers

--- a/device/ser/sysdepend/rx65n/ser_rx65n.c
+++ b/device/ser/sysdepend/rx65n/ser_rx65n.c
@@ -76,7 +76,7 @@ const LOCAL INT pritbl[DEV_SER_UNITNM] = {
 */
 typedef struct {
 	UW	mode;		// Serial mode
-	UW	speed;		// Spped (bit rate)
+	UW	speed;		// Speed (bit rate)
 } T_DEV_SER_LLDEVCB;
 
 LOCAL T_DEV_SER_LLDEVCB		ll_devcb[DEV_SER_UNITNM];

--- a/device/ser/sysdepend/rx65n/ser_sysdep.h
+++ b/device/ser/sysdepend/rx65n/ser_sysdep.h
@@ -20,7 +20,7 @@
 #ifndef	__DEV_SER_RX65N_H__
 #define	__DEV_SER_RX65N_H__
 
-#define	DEV_SER_UNITNM		(13)	/* Number of devive channels */
+#define	DEV_SER_UNITNM		(13)	/* Number of device channels */
 
 /*
  * UART registers

--- a/device/ser/sysdepend/rza2m/ser_rza2m.c
+++ b/device/ser/sysdepend/rza2m/ser_rza2m.c
@@ -60,7 +60,7 @@ const LOCAL struct {
 */
 typedef struct {
 	UW	mode;		// Serial mode
-	UW	speed;		// Spped (bit rate)
+	UW	speed;		// Speed (bit rate)
 } T_DEV_SER_LLDEVCB;
 
 LOCAL T_DEV_SER_LLDEVCB		ll_devcb[DEV_SER_UNITNM];

--- a/device/ser/sysdepend/rza2m/ser_sysdep.h
+++ b/device/ser/sysdepend/rza2m/ser_sysdep.h
@@ -21,7 +21,7 @@
 #ifndef	__DEV_SER_RZA2M_H__
 #define	__DEV_SER_RZA2M_H__
 
-#define	DEV_SER_UNITNM		(5)	/* Number of devive channels */
+#define	DEV_SER_UNITNM		(5)	/* Number of device channels */
 
 /*
  * UART registers

--- a/device/ser/sysdepend/stm32h7/ser_stm32h7.c
+++ b/device/ser/sysdepend/stm32h7/ser_stm32h7.c
@@ -98,7 +98,7 @@ const LOCAL struct {
 */
 typedef struct {
 	UW	mode;		// Serial mode
-	UW	speed;		// Spped (bit rate)
+	UW	speed;		// Speed (bit rate)
 } T_DEV_SER_LLDEVCB;
 
 LOCAL T_DEV_SER_LLDEVCB		ll_devcb[DEV_SER_UNITNM];

--- a/device/ser/sysdepend/stm32h7/ser_sysdep.h
+++ b/device/ser/sysdepend/stm32h7/ser_sysdep.h
@@ -20,7 +20,7 @@
 #ifndef	__DEV_SER_STM32H7_H__
 #define	__DEV_SER_STM32H7_H__
 
-#define	DEV_SER_UNITNM	(10)	/* Number of devive channels */
+#define	DEV_SER_UNITNM	(10)	/* Number of device channels */
 #define DEV_SER_UNIT0	(0)	/* Ch.0 - USART1 */
 #define DEV_SER_UNIT1	(1)	/* Ch.1 - USART2 */
 #define DEV_SER_UNIT2	(2)	/* Ch.2 - USART3 */

--- a/device/ser/sysdepend/stm32l4/ser_stm32l4.c
+++ b/device/ser/sysdepend/stm32l4/ser_stm32l4.c
@@ -77,7 +77,7 @@ const LOCAL struct {
 */
 typedef struct {
 	UW	mode;		// Serial mode
-	UW	speed;		// Spped (bit rate)
+	UW	speed;		// Speed (bit rate)
 } T_DEV_SER_LLDEVCB;
 
 LOCAL T_DEV_SER_LLDEVCB		ll_devcb[DEV_SER_UNITNM];

--- a/device/ser/sysdepend/stm32l4/ser_sysdep.h
+++ b/device/ser/sysdepend/stm32l4/ser_sysdep.h
@@ -21,7 +21,7 @@
 #ifndef	__DEV_SER_STM32L4_H__
 #define	__DEV_SER_STM32L4_H__
 
-#define	DEV_SER_UNITNM	(5)	/* Number of devive channels */
+#define	DEV_SER_UNITNM	(5)	/* Number of device channels */
 #define DEV_SER_UNIT0	(0)	/* Ch.0 - USART1 */
 #define DEV_SER_UNIT1	(1)	/* Ch.1 - USART2 */
 #define DEV_SER_UNIT2	(2)	/* Ch.2 - USART3 */

--- a/device/ser/sysdepend/tx03_m367/ser_m367.c
+++ b/device/ser/sysdepend/tx03_m367/ser_m367.c
@@ -51,7 +51,7 @@ const LOCAL struct {
 */
 typedef struct {
 	UW	mode;		// Serial mode
-	UW	speed;		// Spped (bit rate)
+	UW	speed;		// Speed (bit rate)
 } T_DEV_SER_LLDEVCB;
 
 LOCAL T_DEV_SER_LLDEVCB		ll_devcb[DEV_SER_UNITNM];

--- a/device/ser/sysdepend/tx03_m367/ser_sysdep.h
+++ b/device/ser/sysdepend/tx03_m367/ser_sysdep.h
@@ -21,7 +21,7 @@
 #ifndef	__DEV_SER_M367_H__
 #define	__DEV_SER_M367_H__
 
-#define	DEV_SER_UNITNM		(2)	/* Number of devive channels */
+#define	DEV_SER_UNITNM		(2)	/* Number of device channels */
 #define DEV_SER_UNIT0		(0)	/* UART Ch.4 */
 #define DEV_SER_UNIT1		(1)	/* UART Ch.5 */
 

--- a/include/sys/knldef.h
+++ b/include/sys/knldef.h
@@ -13,7 +13,7 @@
 
 /*
  *	knldef.h
- *	micro T-Kernel system definition form Configulation
+ *	micro T-Kernel system definition form Configuration
  */
 
 #ifndef _SYS_KNLDEF_H_

--- a/include/sys/sysdepend/cpu/core/armv7a/sysdef.h
+++ b/include/sys/sysdepend/cpu/core/armv7a/sysdef.h
@@ -172,7 +172,7 @@
 #define	FPSCR_IOE	0x00000100	/*		invalid operation */
 #define	FPSCR_IDC	0x00000080	/* Except.Flag	input denormal */
 #define	FPSCR_IXC	0x00000010	/*		inexact */
-#define	FPSCR_UFC	0x00000008	/*		undeflow */
+#define	FPSCR_UFC	0x00000008	/*		underflow */
 #define	FPSCR_OFC	0x00000004	/*		overflow */
 #define	FPSCR_DZC	0x00000002	/*		division by zero */
 #define	FPSCR_IOC	0x00000001	/*		invalid operation */

--- a/include/sys/sysdepend/cpu/core/armv7m/sysdef.h
+++ b/include/sys/sysdepend/cpu/core/armv7m/sysdef.h
@@ -87,13 +87,13 @@
 /*
  * The number of the implemented bit width for priority value fields.
  * The LSB of (8-INTPRI_BITWIDTH) bits priority value is ignored, 
- * Bacause each priory bits is INTPRI_BITWIDTH bits.
+ * Because each priory bits is INTPRI_BITWIDTH bits.
  */
 #define INTPRI_VAL(x)	((x) << (8-INTPRI_BITWIDTH))
 
 
 /* SHPR: System Handler Priority Register
- *   SHRP1    (ReV)     Usage     Bus       Memmory
+ *   SHRP1    (ReV)     Usage     Bus       Memory
  *   SHRP2    SVCall    (Rev)     (Rev)     (Rev)
  *   SHPR3    SysTick   PendSV    (Rsv)     DebugMon-
  */

--- a/include/sys/sysdepend/cpu/stm32h7/sysdef.h
+++ b/include/sys/sysdepend/cpu/stm32h7/sysdef.h
@@ -48,7 +48,7 @@
 
 /* ------------------------------------------------------------------------ */
 /*
- * System configuration controler (SYSCFG)
+ * System configuration controller (SYSCFG)
  */
 
 #define SYSCFG_BASE	0x58000400

--- a/include/sys/sysdepend/cpu/stm32l4/sysdef.h
+++ b/include/sys/sysdepend/cpu/stm32l4/sysdef.h
@@ -48,7 +48,7 @@
 
 /* ------------------------------------------------------------------------ */
 /*
- * System configuration controler (SYSCFG)
+ * System configuration controller (SYSCFG)
  */
 
 #define SYSCFG_BASE	0x40010000

--- a/include/tk/sysdepend/cpu/core/armv7m/syslib.h
+++ b/include/tk/sysdepend/cpu/core/armv7m/syslib.h
@@ -27,7 +27,7 @@
 /*
  * CPU interrupt control for ARMv7-M.
  *	As armv7-m architecture does not support disable interrupt in
- *	xpsr register, we have to raise the excution priority to 
+ *	xpsr register, we have to raise the exception priority to 
  *	that the interrupt group have. Write the BASEPRI to implement 
  *	disint.
  */
@@ -47,7 +47,7 @@ IMPORT UW disint(void);			/* Disable interrupt */
 /*
  * Interrupt priority grouping
  *
- *	PRIGROUP in the AIRCR register determins the split of group
+ *	PRIGROUP in the AIRCR register determines the split of group
  *	priority from subpriority. PRIGROUP is initialized to 3
  *	(pri:subpri = 4:4)) in the boot sequence.
  */

--- a/include/tk/syslib.h
+++ b/include/tk/syslib.h
@@ -26,7 +26,7 @@
 
 /* ------------------------------------------------------------------------ */
 /*
- * System dependencies  (CPU Intrrupt contrl , I/O port access)
+ * System dependencies  (CPU Interrupt control , I/O port access)
  */
 #define SYSLIB_PATH_(a)		#a
 #define SYSLIB_PATH(a)		SYSLIB_PATH_(a)

--- a/kernel/knlinc/kernel.h
+++ b/kernel/knlinc/kernel.h
@@ -159,7 +159,7 @@ IMPORT ER knl_subsystem_initialize( void );
 IMPORT ER knl_init_object(void);
 
 /*
- * Initialization of Devive management (device.c)
+ * Initialization of Device management (device.c)
  */
 IMPORT ER knl_initialize_devmgr( void );
 
@@ -236,7 +236,7 @@ IMPORT void knl_force_dispatch( void );
 IMPORT void knl_dispatch( void );
 
 /*
- * Interuupt control (interrupt.c)
+ * Interrupt control (interrupt.c)
  */
 IMPORT ER knl_init_interrupt( void );
 IMPORT ER knl_define_inthdr( INT intno, ATR intatr, FP inthdr );

--- a/kernel/sysdepend/cpu/core/armv7m/sys_timer.h
+++ b/kernel/sysdepend/cpu/core/armv7m/sys_timer.h
@@ -100,7 +100,7 @@ Inline UW knl_get_hw_timer_nsec( void )
 	}
 	EI(imsk);
 	ofs = max - ofs;			/* Elapsed count */
-	if ( unf != 0 ) ofs += max + 1;	/* Reload occured, Adjust */
+	if ( unf != 0 ) ofs += max + 1;	/* Reload occurred, Adjust */
 
 	return  (UW) ( ( (D)ofs * 1000000 ) / TMCLK_KHz );
 }

--- a/kernel/sysdepend/cpu/core/rxv2/interrupt.c
+++ b/kernel/sysdepend/cpu/core/rxv2/interrupt.c
@@ -66,7 +66,7 @@ EXPORT ER knl_define_inthdr( INT intno, ATR intatr, FP inthdr )
 		return E_PAR;
 	}
 
-	if(inthdr != NULL) {	/* define intrrupt handler */
+	if(inthdr != NULL) {	/* define interrupt handler */
 		if ( (intatr & TA_HLNG) != 0 ) {
 			knl_hll_inthdr_ram[intno] = inthdr;
 			inthdr = knl_int_vect_rom[intno];	/* set HLL-Int handler entry */

--- a/kernel/sysdepend/iote_m367/cpu_clock.c
+++ b/kernel/sysdepend/iote_m367/cpu_clock.c
@@ -66,13 +66,13 @@ EXPORT void startup_clock(UB pll_mode)
 		return;
 	}
 	
-	/* Waiting for PLL stablization (100usec) */
+	/* Waiting for PLL stabilization (100usec) */
 	*osccr = (*osccr & 0x000FFFFF) | CLKCTRL_CGOSCCR_WUPT(100, HISPEED_CLOCK_MHz) | (1);
 	while( (*osccr & CLKCTRL_CGOSCCR_WUEF) != 0 ) {
 		;
 	}
 	
-	/* Enable PLL operation and Wait for PLL stablization (200usec) */
+	/* Enable PLL operation and Wait for PLL stabilization (200usec) */
 	*osccr = (*osccr & 0x000FFFFF) | (CLKCTRL_CGOSCCR_PLLON |
 			    CLKCTRL_CGOSCCR_WUPT(200, HISPEED_CLOCK_MHz) | (1));
 	while( (*osccr & CLKCTRL_CGOSCCR_WUEF) != 0 ) {

--- a/kernel/sysdepend/iote_rx231/cpu_clock.c
+++ b/kernel/sysdepend/iote_rx231/cpu_clock.c
@@ -25,7 +25,7 @@
 
 /*
  *  Startup System Clock
- *    Used Main Clock(8MHz), Uesd PLL/UPLL, System Clock 54MHz
+ *    Used Main Clock(8MHz), Used PLL/UPLL, System Clock 54MHz
  *    ICLK:54MHz, PCLKA:54MHz, PCLKB:27MHz, PCLKD:54MHz, FCLK:1.6875MHz, UCLK:48MHz
  */
 EXPORT void startup_clock(void)

--- a/kernel/tkernel/device.c
+++ b/kernel/tkernel/device.c
@@ -502,7 +502,7 @@ err_ret:
 }
 
 /*
- * Initialization of Devive management
+ * Initialization of Device management
  */
 EXPORT ER knl_initialize_devmgr( void )
 {

--- a/kernel/tkernel/ready_queue.h
+++ b/kernel/tkernel/ready_queue.h
@@ -31,7 +31,7 @@
  *	Also, to search a task at the highest priority in the ready queue  
  *    	effectively, put the highest task priority in the 'top_priority' field.
  *	If the ready queue is empty, set the value in this field to NUM_TSKPRI. 
- *	In this case, to return '0' with refering 'tskque[top_priority]',
+ *	In this case, to return '0' with referring 'tskque[top_priority]',
  *      there is 'null' field which is always '0'.
  *
  *	Multiple READY tasks with kernel lock do not exist at the same time.

--- a/lib/libtk/sysdepend/cpu/rx231/int_rx231.c
+++ b/lib/libtk/sysdepend/cpu/rx231/int_rx231.c
@@ -17,7 +17,7 @@
 /*
  *	int.c
  *
- *	Interrupt controll (RX231 )
+ *	Interrupt control (RX231 )
  */
 #include <tk/tkernel.h>
 #include <tk/syslib.h>

--- a/lib/libtk/sysdepend/cpu/rx231/ptimer_rx231.c
+++ b/lib/libtk/sysdepend/cpu/rx231/ptimer_rx231.c
@@ -57,7 +57,7 @@ LOCAL void ptmr_int_main( UINT intno, T_PTMRCB *p_cb)
 	}
 
 	if( p_cb->mode == TA_ALM_PTMR)  {
-		/* Stop Pysical timer */
+		/* Stop Physical timer */
 		DisableInt( intno);
 		out_h(TMR_TCCR, 0);			// Timer Stop
 	}
@@ -206,7 +206,7 @@ EXPORT ER GetPhysicalTimerConfig(UINT ptmrno, T_RPTMR *pk_rptmr)
 			ptmrclk = SYSCLK_PCLKB/8192;
 			break;
 		default:
-			ptmrclk = 0;		// Unkown
+			ptmrclk = 0;		// Unknown
 	}
 	pk_rptmr->ptmrclk	= ptmrclk;
 	pk_rptmr->maxcount	= PTMR_MAX_CNT;

--- a/lib/libtk/sysdepend/cpu/rx65n/int_rx65n.c
+++ b/lib/libtk/sysdepend/cpu/rx65n/int_rx65n.c
@@ -17,7 +17,7 @@
 /*
  *	int.c
  *
- *	Interrupt controll (RX65N )
+ *	Interrupt control (RX65N )
  */
 #include <tk/tkernel.h>
 #include <tk/syslib.h>

--- a/lib/libtk/sysdepend/cpu/rx65n/ptimer_rx65n.c
+++ b/lib/libtk/sysdepend/cpu/rx65n/ptimer_rx65n.c
@@ -57,7 +57,7 @@ LOCAL void ptmr_int_main( UINT intno, T_PTMRCB *p_cb)
 	}
 
 	if( p_cb->mode == TA_ALM_PTMR)  {
-		/* Stop Pysical timer */
+		/* Stop Physical timer */
 		DisableInt( intno);
 		out_h(TMR_TCCR, 0);			// Timer Stop
 	}
@@ -206,7 +206,7 @@ EXPORT ER GetPhysicalTimerConfig(UINT ptmrno, T_RPTMR *pk_rptmr)
 			ptmrclk = SYSCLK_PCLKB/8192;
 			break;
 		default:
-			ptmrclk = 0;		// Unkown
+			ptmrclk = 0;		// Unknown
 	}
 	pk_rptmr->ptmrclk	= ptmrclk;
 	pk_rptmr->maxcount	= PTMR_MAX_CNT;

--- a/lib/libtk/sysdepend/cpu/rza2m/ptimer_rza2m.c
+++ b/lib/libtk/sysdepend/cpu/rza2m/ptimer_rza2m.c
@@ -58,7 +58,7 @@ LOCAL void ptmr_int_main( UINT intno, T_PTMRCB *p_cb)
 	
 	if( p_cb->mode == TA_ALM_PTMR)  {
 		DisableInt( intno);
-		out_b( OSTMn_TT((intno==INTNO_OSTM1)?0:1), 1);	// Stop Pysical timer
+		out_b( OSTMn_TT((intno==INTNO_OSTM1)?0:1), 1);	// Stop Physical timer
 	}
 
 	EndOfInt(intno);

--- a/lib/libtk/sysdepend/cpu/stm32h7/ptimer_stm32h7.c
+++ b/lib/libtk/sysdepend/cpu/stm32h7/ptimer_stm32h7.c
@@ -62,7 +62,7 @@ LOCAL void ptmr_int_main( UINT intno, T_PTMRCB *p_cb)
 	}
 
 	if( p_cb->mode == TA_ALM_PTMR)  {
-		DisableInt( intno);			// Stop Pysical timer
+		DisableInt( intno);			// Stop Physical timer
 	}
 }
 

--- a/lib/libtk/sysdepend/cpu/stm32l4/ptimer_stm32l4.c
+++ b/lib/libtk/sysdepend/cpu/stm32l4/ptimer_stm32l4.c
@@ -62,7 +62,7 @@ LOCAL void ptmr_int_main( UINT intno, T_PTMRCB *p_cb)
 	}
 
 	if( p_cb->mode == TA_ALM_PTMR)  {
-		DisableInt( intno);			// Stop Pysical timer
+		DisableInt( intno);			// Stop Physical timer
 	}
 }
 

--- a/lib/libtk/sysdepend/cpu/tx03_m367/int_m367.c
+++ b/lib/libtk/sysdepend/cpu/tx03_m367/int_m367.c
@@ -55,7 +55,7 @@ EXPORT void ClearInt(UINT intno)
 
 	ClearInt_nvic(intno);		/* Un-pends the associated interrupt */
 
-	/* Clear Clock Generetor Interrupt request */
+	/* Clear Clock Generator Interrupt request */
 	switch (intno) 	{
 	case M367_INTUSBWKUP:
 		val = 12;
@@ -127,7 +127,7 @@ EXPORT void SetIntMode(UINT intno, UINT mode)
 	}
 
 	if(mode & IM_LEVEL) {		
-		e = 0;	/* Level sence */
+		e = 0;	/* Level sense */
 	} else {
 		e = 2;	/* Edge sense */
 	}

--- a/lib/libtk/sysdepend/cpu/tx03_m367/ptimer_m367.c
+++ b/lib/libtk/sysdepend/cpu/tx03_m367/ptimer_m367.c
@@ -63,7 +63,7 @@ LOCAL void ptmr_int_main( UINT intno, T_PTMRCB *p_cb)
 	}
 
 	if( p_cb->mode == TA_ALM_PTMR)  {
-		/* Stop Pysical timer */
+		/* Stop Physical timer */
 		DisableInt( intno);
 		out_w( TMRB_TBxEN, TBxEN_TBEN );	// Timer module disabled.
 	}

--- a/lib/libtm/libtm_printf.c
+++ b/lib/libtm/libtm_printf.c
@@ -17,7 +17,7 @@
  *	printf() / sprintf() T-Monitor compatible calls.
  *
  *	- Unsupported specifiers: floating point, long long and others.
- *		Coversion:	 a, A, e, E, f, F, g, G, n
+ *		Conversion:	 a, A, e, E, f, F, g, G, n
  *		Size qualifier:  hh, ll, j, z, t, L
  *	- No limitation of output string length.
  *	- Minimize stack usage.
@@ -59,7 +59,7 @@ LOCAL const UB  digits[32] = "0123456789abcdef0123456789ABCDEF";
 }
 
 /*
- *	Output with format (limitted version)
+ *	Output with format (limited version)
  */
 LOCAL	void	tm_vsprintf( OutFn ostr, OutPar *par, const UB *fmt, va_list ap )
 {


### PR DESCRIPTION
Utilized a spell checking tool to identify and correct spelling throughout all files in the code base.