### PR TITLE
Add device support to RENESAS EK-RA6M5.

### DIFF
--- a/config/config.h
+++ b/config/config.h
@@ -34,8 +34,8 @@
 /* SYSCONF : micro T-Kernel system configuration
  */
 
-#define	CNF_SYSTEMAREA_TOP	0x24100400	/* 0: Use system default address */
-#define CNF_SYSTEMAREA_END	0x2417FFFF	/* 0: Use system default address */
+#define	CNF_SYSTEMAREA_TOP	0	/* 0: Use system default address */
+#define CNF_SYSTEMAREA_END	0	/* 0: Use system default address */
 
 #define	CNF_MAX_TSKPRI		32	/* Task Max priority */
 

--- a/include/sys/machine.h
+++ b/include/sys/machine.h
@@ -47,6 +47,12 @@
 #define ADD_PREFIX_MAIN_FUNC		(1)
 #endif
 
+#ifdef _RA_EK_RA6M5_EXTSEC_
+#include "sysdepend/ek_ra6m5/machine.h"
+#define Csym(sym) sym
+#define ADD_PREFIX_MAIN_FUNC		(1)
+#endif
+
 /* ===== C compiler dependencies definitions ============================= */
 
 #ifdef __GNUC__

--- a/include/sys/sysdepend/cpu/ra6m5/sysdef.h
+++ b/include/sys/sysdepend/cpu/ra6m5/sysdef.h
@@ -1,0 +1,108 @@
+/*
+ *----------------------------------------------------------------------
+ *    micro T-Kernel 3.00.08.B1
+ *
+ *    Copyright (C) 2006-2025 by Ken Sakamura.
+ *    This software is distributed under the T-License 2.2.
+ *----------------------------------------------------------------------
+ *
+ *    Released by TRON Forum(http://www.tron.org) at 2025/11.
+ *
+ *----------------------------------------------------------------------
+ */
+
+/*
+ *	sysdef.h
+ *
+ *	System dependencies definition (RA6M5 depended)
+ *	Included also from assembler program.
+ */
+
+#ifndef __TK_SYSDEF_DEPEND_CPU_H__
+#define __TK_SYSDEF_DEPEND_CPU_H__
+
+#include "../../../machine.h"
+
+/* CPU Core-dependent definition */
+#include "../core/armv8m/sysdef.h"
+
+/* ------------------------------------------------------------------------ */
+/*
+ * Internal Memorie (Main RAM)
+ */
+/* RA6M5 Internal SRAM0   0x20000000 - 0x2007FFFF  (Size 512KB) */
+#define INTERNAL_RAM_START      0x20000000
+#define INTERNAL_RAM_SIZE       0x0007FFFF
+
+#define INTERNAL_RAM_END        (INTERNAL_RAM_START+INTERNAL_RAM_SIZE)
+
+/* ------------------------------------------------------------------------ */
+/*
+ * Initial Stack pointer (Used in initialization process)
+ */
+#define	INITIAL_SP		INTERNAL_RAM_END
+
+/* ------------------------------------------------------------------------ */
+/*
+ * System Timer clock
+ */
+
+/* Settable interval range (millisecond) */
+#define MIN_TIMER_PERIOD	1
+#define MAX_TIMER_PERIOD	50
+
+/* ------------------------------------------------------------------------ */
+/*
+ * Number of Interrupt vectors
+ */
+#define	N_SYSVEC		16	/* Number of System Exceptions */
+#define N_INTVEC		96	/* Number of Interrupt vectors */
+
+/*
+ * Exception vector table alignment
+*/
+#define	EXCTBL_ALIGN		1024
+
+/*
+ * The number of the implemented bit width for priority value fields.
+ */
+#define INTPRI_BITWIDTH		4
+
+/* ------------------------------------------------------------------------ */
+/*
+ * Interrupt Priority Levels
+ */
+#define INTPRI_MAX_EXTINT_PRI	1	/* Highest Ext. interrupt level */
+#define INTPRI_SVC		0	/* SVCall */
+#define INTPRI_SYSTICK		1	/* SysTick */
+#define INTPRI_PENDSV		15	/* PendSV */
+
+/*
+ * Time-event handler interrupt level
+ */
+#define TIMER_INTLEVEL		0
+
+/* ------------------------------------------------------------------------ */
+/*
+ * Coprocessor
+ */
+#define CPU_HAS_FPU		1
+#define CPU_HAS_DSP		0
+
+/*
+ *  Number of coprocessors to use. Depends on user configuration
+ */
+#if USE_FPU
+#define NUM_COPROCESSOR		1
+#else
+#define NUM_COPROCESSOR		0
+#endif
+
+
+/* ------------------------------------------------------------------------ */
+/*
+ * Physical timer (for RA6M5)
+ */
+#define	CPU_HAS_PTMR	0
+
+#endif /* __TK_SYSDEF_DEPEND_CPU_H__ */

--- a/include/sys/sysdepend/ek_ra6m5/machine.h
+++ b/include/sys/sysdepend/ek_ra6m5/machine.h
@@ -1,0 +1,51 @@
+/*
+ *----------------------------------------------------------------------
+ *    micro T-Kernel 3.00.08.B1
+ *
+ *    Copyright (C) 2006-2025 by Ken Sakamura.
+ *    This software is distributed under the T-License 2.2.
+ *----------------------------------------------------------------------
+ *
+ *    Released by TRON Forum(http://www.tron.org) at 2025/11.
+ *
+ *----------------------------------------------------------------------
+ */
+
+/*
+ *	machine.h
+ *
+ *	Machine type definition (EK-RA6M5 depended)
+ */
+
+#ifndef __SYS_SYSDEPEND_MACHINE_H__
+#define __SYS_SYSDEPEND_MACHINE_H__
+
+/*
+ * [TYPE]_[CPU]		TARGET SYSTEM
+ * CPU_xxxx		CPU type
+ * CPU_CORE_xxx		CPU core type
+ */
+
+/* ----- EK-RA6M5 (CPU: STM32N657X0) definition ----- */
+#define EK_RA6M5		1	/* Target Board    : EK-RA6M5 */
+
+#define CPU_RA6			1	/* Target CPU type : RA6 series */
+#define CPU_RA6M5		1	/* Target CPU      : RA6M5 */
+
+#define CPU_CORE_ARMV8M		1	/* Target CPU-Core type : ARMv8-M */
+#define CPU_CORE_ACM33		1	/* Target CPU-Core      : ARM Cortex-M33 */
+
+#define TARGET_DIR		ek_ra6m5	/* Sysdepend-Directory name */
+#define	TARGET_CPU_DIR		ra6m5		/* Sysdepend-CPU-Directory name */
+
+#define KNL_SYSDEP_PATH		sysdepend/kernel/ek_ra6m5	/* Kernel sysdepend path */
+
+/* ----- Extension definition ----*/
+#define EXT_SEC		1	/* Secure Extension for Arm (TrustZone) */
+
+/*
+ **** CPU Core depended profile (ARMv8M)
+ */
+#include "../cpu/core/armv8m/machine.h"
+
+#endif /* __SYS_SYSDEPEND_MACHINE_H__ */

--- a/include/sys/sysdepend/ek_ra6m5/profile.h
+++ b/include/sys/sysdepend/ek_ra6m5/profile.h
@@ -1,0 +1,37 @@
+/*
+ *----------------------------------------------------------------------
+ *    micro T-Kernel 3.00.08.B1
+ *
+ *    Copyright (C) 2006-2025 by Ken Sakamura.
+ *    This software is distributed under the T-License 2.2.
+ *----------------------------------------------------------------------
+ *
+ *    Released by TRON Forum(http://www.tron.org) at 2025/11.
+ *
+ *----------------------------------------------------------------------
+ */
+
+/*
+ *	profile.h
+ *
+ *	Service Profile (EK-RA6M5)
+ */
+
+#ifndef __SYS_DEPEND_PROFILE_H__
+#define __SYS_DEPEND_PROFILE_H__
+
+/*
+ **** CPU Core depended profile (ARMv8M)
+ */
+#include "../cpu/core/armv8m/profile.h"
+
+/*
+ **** Target-depeneded profile (EK-RA6M5)
+ */
+
+/*
+ * Power management
+ */
+#define TK_SUPPORT_LOWPOWER	FALSE		/* Support of power management */
+
+#endif /* __SYS_DEPEND_PROFILE_H__ */

--- a/include/sys/sysdepend/ek_ra6m5/sysdef.h
+++ b/include/sys/sysdepend/ek_ra6m5/sysdef.h
@@ -1,0 +1,62 @@
+/*
+ *----------------------------------------------------------------------
+ *    micro T-Kernel 3.00.08.B1
+ *
+ *    Copyright (C) 2006-2025 by Ken Sakamura.
+ *    This software is distributed under the T-License 2.2.
+ *----------------------------------------------------------------------
+ *
+ *    Released by TRON Forum(http://www.tron.org) at 2025/11.
+ *
+ *----------------------------------------------------------------------
+ */
+
+/*
+ *	sysdef.h
+ *
+ *	System dependencies definition (EK-RA6M5 depended)
+ *	Included also from assembler program.
+ */
+
+#ifndef __SYS_SYSDEF_DEPEND_H__
+#define __SYS_SYSDEF_DEPEND_H__
+
+/* ------------------------------------------------------------------------ */
+/* TrustZone settings
+ * (This setting reflects the configuration setting.)
+ */
+/* TrustZone defined */
+#define TRUSTZONE_ENABLE	(CNF_TZ_ENABLE)				// TrustZone Enabled
+#define TRUSTZONE_SECURE	(CNF_TZ_ENABLE && CNF_TZ_STATE)		// OS in Secure status
+#define TRUSTZONE_NONSECURE	(CNF_TZ_ENABLE && !CNF_TZ_STATE)	// OS in Non-Secure status
+
+// Enable Secure Calls from Tasks
+#define TRUSTZONE_SCALL	(TRUSTZONE_NONSECURE && CNF_TZ_SCALL)
+
+#ifndef _in_asm_source_
+/* ------------------------------------------------------------------------ */
+/* System clock settings
+ */
+IMPORT UW knl_sysclk;		// System clock
+
+#define	SYSCLK			knl_sysclk	// System clock
+
+//#define SYST_CLK_SRC		0x00000000	/* No systick clock */
+
+#define TMCLK_KHz		(SYSCLK / 1000)		/* System timer clock input (kHz) */
+#define TMCLK			(TMCLK_KHz / 1000)	/* System timer clock input (MHz) */
+
+/* ------------------------------------------------------------------------ */
+/* System Memory Area information
+ *     UNUSED_RAM_TOP: Start address of unused area in RAM
+ *     (This information is obtained from the linker information.)
+ */
+IMPORT const void		*_end;
+#define UNUSED_RAM_TOP		((UW)&_end)
+
+#endif	/* _in_asm_source_ */
+
+/* CPU-dependent definition */
+#include "../cpu/ra6m5/sysdef.h"
+
+#endif /* __SYS_SYSDEF_DEPEND_H__ */

--- a/include/tk/sysdepend/cpu/ra6m5/syslib.h
+++ b/include/tk/sysdepend/cpu/ra6m5/syslib.h
@@ -1,0 +1,38 @@
+/*
+ *----------------------------------------------------------------------
+ *    micro T-Kernel 3.00.08.B1
+ *
+ *    Copyright (C) 2025 by Ken Sakamura.
+ *    This software is distributed under the T-License 2.2.
+ *----------------------------------------------------------------------
+ *
+ *    Released by TRON Forum(http://www.tron.org) at 2025/11.
+ *
+ *----------------------------------------------------------------------
+ */
+
+/*
+ *	syslib.h
+ *
+ *	micro T-Kernel System Library  (RA6M5 depended)
+ */
+
+#ifndef __TK_SYSLIB_CPU_DEPEND_H__
+#define __TK_SYSLIB_CPU_DEPEND_H__
+
+#include "../core/armv8m/syslib.h"
+
+/* ------------------------------------------------------------------------ */
+/*
+ * Interrupt Control
+ */
+
+/*
+ * Interrupt mode ( Use SetIntMode )
+ */
+#define IM_EDGE		0x0000		/* Edge trigger */
+#define IM_HI		0x0002		/* Interrupt at rising edge */
+#define IM_LOW		0x0001		/* Interrupt at falling edge */
+#define IM_BOTH		0x0003		/* Interrupt at both edge */
+
+#endif /* __TK_SYSLIB_CPU_DEPEND_H__ */

--- a/include/tk/sysdepend/ek_ra6m5/cpudef.h
+++ b/include/tk/sysdepend/ek_ra6m5/cpudef.h
@@ -1,0 +1,25 @@
+/*
+ *----------------------------------------------------------------------
+ *    micro T-Kernel 3.00.08.B1
+ *
+ *    Copyright (C) 2006-2025 by Ken Sakamura.
+ *    This software is distributed under the T-License 2.2.
+ *----------------------------------------------------------------------
+ *
+ *    Released by TRON Forum(http://www.tron.org) at 2025/11.
+ *
+ *----------------------------------------------------------------------
+ */
+
+/*
+ *	cpudef.h
+ *
+ *	CPU dependent definition (EK-RA6M5 depended)
+ */
+
+#ifndef __TK_CPUDEF_DEPEND__H__
+#define __TK_CPUDEF_DEPEND__H__
+
+#include "../cpu/core/armv8m/cpudef.h"
+
+#endif /* __TK_CPUDEF_DEPEND__H__ */

--- a/include/tk/sysdepend/ek_ra6m5/syslib.h
+++ b/include/tk/sysdepend/ek_ra6m5/syslib.h
@@ -1,0 +1,25 @@
+/*
+ *----------------------------------------------------------------------
+ *    micro T-Kernel 3.00.08.B1
+ *
+ *    Copyright (C) 2006-2025 by Ken Sakamura.
+ *    This software is distributed under the T-License 2.2.
+ *----------------------------------------------------------------------
+ *
+ *    Released by TRON Forum(http://www.tron.org) at 2025/11.
+ *
+ *----------------------------------------------------------------------
+ */
+
+/*
+ *	syslib.h
+ *
+ *	micro T-Kernel System Library  (EK-RA6M5 depended)
+ */
+
+#ifndef __TK_SYSLIB_DEPEND_H__
+#define __TK_SYSLIB_DEPEND_H__
+
+#include "../cpu/ra6m5/syslib.h"
+
+#endif /* __TK_SYSLIB_DEPEND_H__ */


### PR DESCRIPTION
EK-RA6M5 TrustZone対応のため、EK-RA6M5対応のためのヘッダーファイルや、定義の追加をしたので、レビューをよろしくお願いいたします。

主に以下の変更を行いました。
 * CNF_SYSTEMAREA_TOPとCNF_SYSTEMAREA_ENDの定義は現状ではSTM32N657専用のものであるので、一般的な0に変更しました。
 * EK-RA6M5のTrustZone対応に必要なヘッダーファイルを追加しました。